### PR TITLE
Filters

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ setup(
     install_requires=[
         'requests',
         'six',
+        'pytz',
     ],
     extras_require={
         'test': [

--- a/taxii2client/__init__.py
+++ b/taxii2client/__init__.py
@@ -169,7 +169,7 @@ class Status(_TAXIIEndpoint):
             self.refresh()
 
     def __nonzero__(self):
-        return self.status == u"complete"
+        return self.status == "complete"
     __bool__ = __nonzero__
 
     def refresh(self):
@@ -289,11 +289,11 @@ class Collection(_TAXIIEndpoint):
 
     def _verify_can_read(self):
         if not self.can_read:
-            raise AccessError(u"Collection '%s' does not allow reading." % self.url)
+            raise AccessError("Collection '%s' does not allow reading." % self.url)
 
     def _verify_can_write(self):
         if not self.can_write:
-            raise AccessError(u"Collection '%s' does not allow writing." % self.url)
+            raise AccessError("Collection '%s' does not allow writing." % self.url)
 
     def refresh(self):
         response = self._conn.get(self.url, accept=MEDIA_TYPE_TAXII_V20)
@@ -347,23 +347,23 @@ class Collection(_TAXIIEndpoint):
         """
         self._verify_can_write()
         headers = {
-            u"Accept": MEDIA_TYPE_TAXII_V20,
-            u"Content-Type": MEDIA_TYPE_STIX_V20,
+            "Accept": MEDIA_TYPE_TAXII_V20,
+            "Content-Type": MEDIA_TYPE_STIX_V20,
         }
         status_json = self._conn.post(self.objects_url, headers=headers, json=bundle)
 
-        status_url = urlparse.urljoin(self.url, u"../../status/{}".format(
-            status_json[u"id"]))
+        status_url = urlparse.urljoin(self.url, "../../status/{}".format(
+            status_json["id"]))
 
         status = Status(url=status_url, conn=self._conn, **status_json)
 
-        if not wait_for_completion or status.status == u"complete":
+        if not wait_for_completion or status.status == "complete":
             return status
 
         # TODO: consider moving this to a "Status.wait_until_final()" function.
         start_time = time.time()
         elapsed = 0
-        while status.status != u"complete" and \
+        while status.status != "complete" and \
                 (timeout <= 0 or elapsed < timeout):
             time.sleep(poll_interval)
             status.refresh()

--- a/taxii2client/__init__.py
+++ b/taxii2client/__init__.py
@@ -1,4 +1,9 @@
+from __future__ import unicode_literals
+
+import datetime
+import pytz
 import requests
+import six
 import six.moves.urllib.parse as urlparse
 import time
 
@@ -20,6 +25,105 @@ class AccessError(TAXIIServiceException):
     """Attempt was made to read/write to a collection when the collection
     doesn't allow that operation."""
     pass
+
+
+def _format_datetime(dttm):
+    """Convert a datetime object into a valid STIX timestamp string.
+
+    1. Convert to timezone-aware
+    2. Convert to UTC
+    3. Format in ISO format
+    4. Ensure correct precision
+       a. Add subsecond value if non-zero and precision not defined
+    5. Add "Z"
+
+    """
+
+    if dttm.tzinfo is None or dttm.tzinfo.utcoffset(dttm) is None:
+        # dttm is timezone-naive; assume UTC
+        zoned = pytz.utc.localize(dttm)
+    else:
+        zoned = dttm.astimezone(pytz.utc)
+    ts = zoned.strftime("%Y-%m-%dT%H:%M:%S")
+    ms = zoned.strftime("%f")
+    precision = getattr(dttm, "precision", None)
+    if precision == 'second':
+        pass  # Already precise to the second
+    elif precision == "millisecond":
+        ts = ts + '.' + ms[:3]
+    elif zoned.microsecond > 0:
+        ts = ts + '.' + ms.rstrip("0")
+    return ts + "Z"
+
+
+def _ensure_datetime_to_string(maybe_dttm):
+    """If maybe_dttm is a datetime instance, convert to a STIX-compliant
+    string representation.  Otherwise return the value unchanged."""
+    if isinstance(maybe_dttm, datetime.datetime):
+        maybe_dttm = _format_datetime(maybe_dttm)
+    return maybe_dttm
+
+
+def _add_filters_to_url(url, filter_kwargs):
+    """
+    Add the given filters as query parameters to the given URL, and return it.
+    Supported keys are roughly from the spec: "version", "added_after", "id",
+    "type", "version".  The last three are for the "match" filters; you don't
+    need to add "match[]" around them.
+
+    Each value can be a single value or iterable of values.  For the filters
+    whose values are timestamps, datetime.datetime instances are accepted.
+    Other than that, all values must be strings.  None values, empty lists, etc
+    are silently ignored.
+
+    :param url: The url to add query parameters to
+    :param filter_kwargs: The filter information, as a mapping
+    :return: The augmented URL
+    """
+    query_params = {}
+    for kwarg, arglist in six.iteritems(filter_kwargs):
+        # If user passes an empty list, None, etc, silently skip?
+        if not arglist:
+            continue
+
+        # force iterability, for the sake of code uniformity
+        if not hasattr(arglist, "__iter__") or \
+                isinstance(arglist, six.string_types):
+            arglist = arglist,
+
+        if kwarg in ("id", "type"):
+            query_params["match[" + kwarg + "]"] = ",".join(arglist)
+
+        elif kwarg == "version":
+            query_params["match[version]"] = ",".join(
+                _ensure_datetime_to_string(val) for val in arglist
+            )
+
+        elif kwarg == "added_after":
+            if len(arglist) > 1:
+                raise InvalidArgumentsError('No more than one value for filter'
+                                            ' "added_after" may be given')
+
+            query_params["added_after"] = ",".join(
+                _ensure_datetime_to_string(val) for val in arglist
+            )
+
+        else:
+            raise InvalidArgumentsError("Unknown filter type: " + kwarg)
+
+    if query_params:
+        encoded_params = urlparse.urlencode(query_params)
+        url_parts = urlparse.urlsplit(url)
+        # replace existing query params if any, vs merging?
+        url = urlparse.urlunsplit((
+            url_parts[0],
+            url_parts[1],
+            url_parts[2],
+            encoded_params,
+            url_parts[4]
+        ))
+
+    return url
 
 
 class _TAXIIEndpoint(object):
@@ -197,16 +301,18 @@ class Collection(_TAXIIEndpoint):
 
         self._loaded = True
 
-    def get_objects(self, filters=None):
+    def get_objects(self, **filter_kwargs):
         """Implement the ``Get Objects`` endpoint (section 5.3)"""
-        # TODO: add filters
         self._verify_can_read()
-        return self._conn.get(self.objects_url, accept=MEDIA_TYPE_STIX_V20)
+        url = _add_filters_to_url(self.objects_url, filter_kwargs)
+        return self._conn.get(url, accept=MEDIA_TYPE_STIX_V20)
 
-    def get_object(self, obj_id):
+    def get_object(self, obj_id, version=None):
         """Implement the ``Get an Object`` endpoint (section 5.5)"""
         self._verify_can_read()
         url = self.objects_url + str(obj_id) + '/'
+        if version:
+            url = _add_filters_to_url(url, {"version": version})
         return self._conn.get(url, accept=MEDIA_TYPE_STIX_V20)
 
     def add_objects(self, bundle, wait_for_completion=True, poll_interval=1,
@@ -265,12 +371,13 @@ class Collection(_TAXIIEndpoint):
 
         return status
 
-    def get_manifest(self, filters=None):
+    def get_manifest(self, **filter_kwargs):
         """Implement the ``Get Object Manifests`` endpoint (section 5.6)."""
         # TODO: add filters
         self._verify_can_read()
-        return self._conn.get(self.url + 'manifest/',
-                              accept=MEDIA_TYPE_TAXII_V20)
+        url = _add_filters_to_url(self.url + 'manifest/',
+                                  filter_kwargs)
+        return self._conn.get(url, accept=MEDIA_TYPE_TAXII_V20)
 
 
 class ApiRoot(_TAXIIEndpoint):

--- a/taxii2client/test/test_client.py
+++ b/taxii2client/test/test_client.py
@@ -1,5 +1,4 @@
 import datetime
-import re
 
 import pytest
 import responses

--- a/taxii2client/test/test_client.py
+++ b/taxii2client/test/test_client.py
@@ -442,12 +442,12 @@ def test_url_filter_version():
 
     now = datetime.datetime.now()
     url = _add_filters_to_url("http://www.example.com", {"version": now})
-    assert re.match(r"^http://www.example.com\?match%5Bversion%5D=\d\d\d\d-\d\d-\d\dT\d\d%3A\d\d%3A\d\d(\.\d+)?Z$",
+    assert re.match(r"^http://www\.example\.com\?match%5Bversion%5D=\d\d\d\d-\d\d-\d\dT\d\d%3A\d\d%3A\d\d(\.\d+)?Z$",
                     url)
 
     url = _add_filters_to_url("http://www.example.com", {"version":
                                                          (now, "bar")})
-    assert re.match(r"^http://www.example.com\?match%5Bversion%5D=\d\d\d\d-\d\d-\d\dT\d\d%3A\d\d%3A\d\d(\.\d+)?Z%2Cbar$",
+    assert re.match(r"^http://www\.example\.com\?match%5Bversion%5D=\d\d\d\d-\d\d-\d\dT\d\d%3A\d\d%3A\d\d(\.\d+)?Z%2Cbar$",
                     url)
 
 
@@ -457,7 +457,7 @@ def test_url_filter_added_after():
 
     now = datetime.datetime.now()
     url = _add_filters_to_url("http://www.example.com", {"added_after": now})
-    assert re.match(r"^http://www.example.com\?added_after=\d\d\d\d-\d\d-\d\dT\d\d%3A\d\d%3A\d\d(\.\d+)?Z$",
+    assert re.match(r"^http://www\.example\.com\?added_after=\d\d\d\d-\d\d-\d\dT\d\d%3A\d\d%3A\d\d(\.\d+)?Z$",
                     url)
 
     with pytest.raises(InvalidArgumentsError):

--- a/taxii2client/test/test_client.py
+++ b/taxii2client/test/test_client.py
@@ -440,7 +440,7 @@ def test_filter_version():
     params = _filter_kwargs_to_query_params({"version": "foo"})
     assert params == {"match[version]": "foo"}
 
-    dt = datetime.datetime(2010,9,8,7,6,5)
+    dt = datetime.datetime(2010, 9, 8, 7, 6, 5)
     params = _filter_kwargs_to_query_params({"version": dt})
     assert params == {"match[version]": "2010-09-08T07:06:05Z"}
 
@@ -452,7 +452,7 @@ def test_filter_added_after():
     params = _filter_kwargs_to_query_params({"added_after": "foo"})
     assert params == {"added_after": "foo"}
 
-    dt = datetime.datetime(2010,9,8,7,6,5)
+    dt = datetime.datetime(2010, 9, 8, 7, 6, 5)
     params = _filter_kwargs_to_query_params({"added_after": dt})
     assert params == {"added_after": "2010-09-08T07:06:05Z"}
 
@@ -461,7 +461,7 @@ def test_filter_added_after():
 
 
 def test_filter_combo():
-    dt = datetime.datetime(2010,9,8,7,6,5)
+    dt = datetime.datetime(2010, 9, 8, 7, 6, 5)
     params = _filter_kwargs_to_query_params({
         "added_after": dt,
         "type": ("indicator", "malware"),


### PR DESCRIPTION
Comments:
- API-wise, they are implemented as keyword args to the relevant methods (as opposed to python-stix2's Filter objects).
    * Kwarg values can be either strings, or for those which accept timestamps, `datetime.datetime` instances, or iterables of these.
    * I blatantly stole `format_datetime()` from python-stix2 to format the datetime objects as STIX-compliant timestamp strings.
- Error checking is minimal.  It is necessary on the server, but seems more optional here.  I kept it quite simple, but more is possible.
    * An error is raised if:
        + an unrecognized kwarg is given
        + `added_after` is given more than one value
    * No format or value checking is done.  E.g. to check whether a version is "last"/"first"/"all" or a timestamp.  It's all just passed through.
- URL escaping is done via `urlparse.urlencode()` (or its python3 equivalent), which escapes a lot of characters.  More than is shown in the spec examples.  Shouldn't hurt though...?
- I added the `unicode_literals` future.  First time I've used it.  I changed all unicode literals to plain string literals.
- You can't test actual filtering of data, since that's the job of the server.  The only thing you can really test is how the URLs are decorated with query parameters.  So that's how most of the tests are written.

Fixes #8.