### PR TITLE
apiroot is not sharing the same connection as everything else

### DIFF
--- a/taxii2client/__init__.py
+++ b/taxii2client/__init__.py
@@ -528,7 +528,7 @@ class Server(_TAXIIEndpoint):
         self._description = response.get('description')
         self._contact = response.get('contact')
         roots = response.get('api_roots', [])
-        self._api_roots = [ApiRoot(url, self._user, self._password)
+        self._api_roots = [ApiRoot(url, conn=self._conn)
                            for url in roots]
         # If 'default' is one of the existing API Roots, reuse that object
         # rather than creating a duplicate. The TAXII 2.0 spec says that the


### PR DESCRIPTION
currently if I implement my own HTTP Connection ( to handle special stuff like proxy, cacert, client cert and all other good stuff , ignore cert warnings ) 
it will not be passed to the api root (as it was only taking user/password).
so in my poc, I was able to connect to my ssl server (since I provided my connection) but not able to get the collections (cause it ignoring my connection)