### PR TITLE
WIP: Issue 24, TODOS, and others

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,25 +3,15 @@ language: python
 cache: pip
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
-  - "3.5-dev"
   - "3.6"
-  - "3.6-dev"
-  - "nightly"
-matrix:
-  allow_failures:
-    - python: "nightly"
 install:
   - pip install -U pip setuptools
   - pip install tox-travis pre-commit
   - pip install codecov
 script:
   - tox
-  # Recent versions of isort don't support Python 3.3
-  # The pre-commit hooks get run enough other places that it's OK to skip them
-  # here.
-  - if [[ $TRAVIS_PYTHON_VERSION != 3.3 ]]; then pre-commit run --all-files; fi
+  - pre-commit run --all-files
 after_success:
   - codecov

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,0 +1,10 @@
+Version 0.2.0
+2017-11-07
+- Filter keyword arguments to query params
+- Add datetime formatting
+- Improve README documentation
+- Improve code coverage/testing
+
+Version 0.1.0
+2017-11-07
+- Initial release

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include LICENSE
+include CHANGES.txt
+recursive-exclude taxii2client\test *

--- a/setup.py
+++ b/setup.py
@@ -4,11 +4,12 @@ import os.path
 
 from setuptools import find_packages, setup
 
-here = os.path.abspath(os.path.dirname(__file__))
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+VERSION_FILE = os.path.join(BASE_DIR, 'taxii2client', 'version.py')
 
 
 def get_version():
-    with open('taxii2client/version.py', encoding="utf-8") as f:
+    with open(VERSION_FILE) as f:
         for line in f.readlines():
             if line.startswith("__version__"):
                 version = line.split()[-1].strip('"')
@@ -16,9 +17,8 @@ def get_version():
         raise AttributeError("Package does not have a __version__")
 
 
-with open(os.path.join(here, 'README.rst'), encoding='utf-8') as f:
+with open('README.rst')as f:
     long_description = f.read()
-
 
 setup(
     name='taxii2-client',

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
         'Programming Language :: Python :: 3.6',
     ],
     keywords="taxii taxii2 client json cti cyber threat intelligence",
-    packages=find_packages(),
+    packages=find_packages(exclude=['*.test']),
     install_requires=[
         'requests',
         'six',

--- a/taxii2client/__init__.py
+++ b/taxii2client/__init__.py
@@ -9,6 +9,8 @@ import requests
 import six
 import six.moves.urllib.parse as urlparse
 
+from taxii2client.version import __version__  # noqa
+
 MEDIA_TYPE_STIX_V20 = "application/vnd.oasis.stix+json; version=2.0"
 MEDIA_TYPE_TAXII_V20 = "application/vnd.oasis.taxii+json; version=2.0"
 

--- a/taxii2client/__init__.py
+++ b/taxii2client/__init__.py
@@ -54,12 +54,12 @@ def _format_datetime(dttm):
     ts = zoned.strftime("%Y-%m-%dT%H:%M:%S")
     ms = zoned.strftime("%f")
     precision = getattr(dttm, "precision", None)
-    if precision == 'second':
+    if precision == "second":
         pass  # Already precise to the second
     elif precision == "millisecond":
-        ts = ts + '.' + ms[:3]
+        ts = ts + "." + ms[:3]
     elif zoned.microsecond > 0:
-        ts = ts + '.' + ms.rstrip("0")
+        ts = ts + "." + ms.rstrip("0")
     return ts + "Z"
 
 
@@ -110,8 +110,8 @@ def _filter_kwargs_to_query_params(filter_kwargs):
 
         elif kwarg == "added_after":
             if len(arglist) > 1:
-                raise InvalidArgumentsError('No more than one value for filter'
-                                            ' "added_after" may be given')
+                raise InvalidArgumentsError("No more than one value for filter"
+                                            " 'added_after' may be given")
 
             query_params["added_after"] = ",".join(
                 _ensure_datetime_to_string(val) for val in arglist
@@ -130,7 +130,7 @@ class _TAXIIEndpoint(object):
     resources are released.
 
     """
-    def __init__(self, url, user=None, password=None, verify=True, conn=None):
+    def __init__(self, url, conn=None, user=None, password=None, verify=True):
         """Create a TAXII endpoint.
 
         Args:
@@ -173,7 +173,7 @@ class Status(_TAXIIEndpoint):
     # than just getting them returned from Collection.add_objects(), and there
     # aren't other endpoints to call on the Status object.
 
-    def __init__(self, url, user=None, password=None, verify=True, conn=None,
+    def __init__(self, url, conn=None, user=None, password=None, verify=True,
                  **kwargs):
         """Create an API root resource endpoint.
 
@@ -185,7 +185,7 @@ class Status(_TAXIIEndpoint):
                 to providing username/password
 
         """
-        super(Status, self).__init__(url, user, password, verify, conn)
+        super(Status, self).__init__(url, conn, user, password, verify)
         if kwargs:
             self._populate_fields(**kwargs)
         else:
@@ -284,7 +284,7 @@ class Collection(_TAXIIEndpoint):
 
     """
 
-    def __init__(self, url, user=None, password=None, verify=True, conn=None,
+    def __init__(self, url, conn=None, user=None, password=None, verify=True,
                  **kwargs):
         """
         Initialize a new Collection.  Either user/password or conn may be
@@ -306,7 +306,7 @@ class Collection(_TAXIIEndpoint):
 
         """
 
-        super(Collection, self).__init__(url, user, password, verify, conn)
+        super(Collection, self).__init__(url, conn, user, password, verify)
 
         self._loaded = False
 
@@ -350,7 +350,7 @@ class Collection(_TAXIIEndpoint):
 
     @property
     def objects_url(self):
-        return self.url + 'objects/'
+        return self.url + "objects/"
 
     def _populate_fields(self, id=None, title=None, description=None,
                          can_read=None, can_write=None, media_types=None):
@@ -399,7 +399,7 @@ class Collection(_TAXIIEndpoint):
     def get_object(self, obj_id, version=None):
         """Implement the ``Get an Object`` endpoint (section 5.5)"""
         self._verify_can_read()
-        url = self.objects_url + str(obj_id) + '/'
+        url = self.objects_url + str(obj_id) + "/"
         query_params = None
         if version:
             query_params = _filter_kwargs_to_query_params({"version": version})
@@ -475,7 +475,7 @@ class Collection(_TAXIIEndpoint):
         """Implement the ``Get Object Manifests`` endpoint (section 5.6)."""
         self._verify_can_read()
         query_params = _filter_kwargs_to_query_params(filter_kwargs)
-        return self._conn.get(self.url + 'manifest/',
+        return self._conn.get(self.url + "manifest/",
                               accept=MEDIA_TYPE_TAXII_V20,
                               params=query_params)
 
@@ -497,7 +497,7 @@ class ApiRoot(_TAXIIEndpoint):
 
     """
 
-    def __init__(self, url, user=None, password=None, verify=True, conn=None):
+    def __init__(self, url, conn=None, user=None, password=None, verify=True):
         """Create an API root resource endpoint.
 
         Args:
@@ -508,7 +508,7 @@ class ApiRoot(_TAXIIEndpoint):
                 to providing username/password
 
         """
-        super(ApiRoot, self).__init__(url, user, password, verify, conn)
+        super(ApiRoot, self).__init__(url, conn, user, password, verify)
 
         self._loaded_collections = False
         self._loaded_information = False
@@ -555,10 +555,10 @@ class ApiRoot(_TAXIIEndpoint):
         """
         response = self._conn.get(self.url, accept=MEDIA_TYPE_TAXII_V20)
 
-        self._title = response['title']
-        self._description = response['description']
-        self._versions = response['versions']
-        self._max_content_length = response['max_content_length']
+        self._title = response["title"]
+        self._description = response["description"]
+        self._versions = response["versions"]
+        self._max_content_length = response["max_content_length"]
 
         self._loaded_information = True
 
@@ -567,12 +567,12 @@ class ApiRoot(_TAXIIEndpoint):
 
         This invokes the ``Get Collections`` endpoint.
         """
-        url = self.url + 'collections/'
+        url = self.url + "collections/"
         response = self._conn.get(url, accept=MEDIA_TYPE_TAXII_V20)
 
         self._collections = []
-        for item in response['collections']:
-            collection_url = url + item['id'] + "/"
+        for item in response["collections"]:
+            collection_url = url + item["id"] + "/"
             collection = Collection(collection_url, conn=self._conn, **item)
             self._collections.append(collection)
 
@@ -600,7 +600,7 @@ class Server(_TAXIIEndpoint):
 
     """
 
-    def __init__(self, url, user=None, password=None, verify=True, conn=None):
+    def __init__(self, url, conn=None, user=None, password=None, verify=True):
         """Create a server discovery endpoint.
 
         Args:
@@ -611,7 +611,7 @@ class Server(_TAXIIEndpoint):
                 to providing username/password
 
         """
-        super(Server, self).__init__(url, user, password, verify, conn)
+        super(Server, self).__init__(url, conn, user, password, verify)
 
         self._user = user
         self._password = password
@@ -649,17 +649,17 @@ class Server(_TAXIIEndpoint):
     def refresh(self):
         response = self._conn.get(self.url, accept=MEDIA_TYPE_TAXII_V20)
 
-        self._title = response['title']
-        self._description = response.get('description')
-        self._contact = response.get('contact')
-        roots = response.get('api_roots', [])
+        self._title = response["title"]
+        self._description = response.get("description")
+        self._contact = response.get("contact")
+        roots = response.get("api_roots", [])
         self._api_roots = [ApiRoot(url, self._user, self._password)
                            for url in roots]
         # If 'default' is one of the existing API Roots, reuse that object
         # rather than creating a duplicate. The TAXII 2.0 spec says that the
         # `default` API Root MUST be an item in `api_roots`.
         root_dict = dict(zip(roots, self._api_roots))
-        self._default = root_dict.get(response.get('default'))
+        self._default = root_dict.get(response.get("default"))
 
         self._loaded = True
 
@@ -707,13 +707,13 @@ class _HTTPConnection(object):
 
         """
         headers = {
-            'Accept': accept
+            "Accept": accept
         }
         resp = self.session.get(url, headers=headers, params=params)
 
         resp.raise_for_status()
 
-        content_type = resp.headers['Content-Type']
+        content_type = resp.headers["Content-Type"]
         if not content_type.startswith(accept):
             msg = "Unexpected Response Content-Type: {}"
             raise TAXIIServiceException(msg.format(content_type))

--- a/taxii2client/__init__.py
+++ b/taxii2client/__init__.py
@@ -654,8 +654,10 @@ class Server(_TAXIIEndpoint):
         self._description = response.get("description")
         self._contact = response.get("contact")
         roots = response.get("api_roots", [])
-        self._api_roots = [ApiRoot(url, self._conn, self._user, self._password,
-                                   self._verify)
+        self._api_roots = [ApiRoot(url,
+                                   user=self._user,
+                                   password=self._password,
+                                   verify=self._verify)
                            for url in roots]
         # If 'default' is one of the existing API Roots, reuse that object
         # rather than creating a duplicate. The TAXII 2.0 spec says that the

--- a/taxii2client/__init__.py
+++ b/taxii2client/__init__.py
@@ -615,6 +615,7 @@ class Server(_TAXIIEndpoint):
 
         self._user = user
         self._password = password
+        self._verify = verify
         self._loaded = False
 
     @property
@@ -649,11 +650,12 @@ class Server(_TAXIIEndpoint):
     def refresh(self):
         response = self._conn.get(self.url, accept=MEDIA_TYPE_TAXII_V20)
 
-        self._title = response["title"]
+        self._title = response.get("title")
         self._description = response.get("description")
         self._contact = response.get("contact")
         roots = response.get("api_roots", [])
-        self._api_roots = [ApiRoot(url, self._user, self._password)
+        self._api_roots = [ApiRoot(url, self._conn, self._user, self._password,
+                                   self._verify)
                            for url in roots]
         # If 'default' is one of the existing API Roots, reuse that object
         # rather than creating a duplicate. The TAXII 2.0 spec says that the

--- a/taxii2client/__init__.py
+++ b/taxii2client/__init__.py
@@ -510,7 +510,7 @@ class Server(_TAXIIEndpoint):
 
     """
 
-    def __init__(self, url, user=None, password=None, conn=None):
+    def __init__(self, url, user=None, password=None, verify=True, conn=None):
         """Create a server discovery endpoint.
 
         Args:
@@ -521,7 +521,7 @@ class Server(_TAXIIEndpoint):
                 providing username/password
 
         """
-        super(Server, self).__init__(url, user, password, conn)
+        super(Server, self).__init__(url, user, password, verify, conn)
 
         self._user = user
         self._password = password

--- a/taxii2client/test/test_client.py
+++ b/taxii2client/test/test_client.py
@@ -8,8 +8,8 @@ import six
 from taxii2client import (
     MEDIA_TYPE_STIX_V20, MEDIA_TYPE_TAXII_V20, AccessError, ApiRoot,
     Collection, InvalidArgumentsError, Server, TAXIIServiceException,
-    ValidationError, _TAXIIEndpoint, _HTTPConnection, get_collection_by_id,
-    _filter_kwargs_to_query_params
+    ValidationError, _filter_kwargs_to_query_params, _HTTPConnection,
+    _TAXIIEndpoint, get_collection_by_id
 )
 
 TAXII_SERVER = "example.com"

--- a/tox.ini
+++ b/tox.ini
@@ -37,7 +37,6 @@ commands =
 [travis]
 python =
   2.7: py27, pycodestyle
-  3.3: py33, pycodestyle
   3.4: py34, pycodestyle
   3.5: py35, pycodestyle
   3.6: py36, pycodestyle

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py33,py34,py35,py36,pycodestyle,isort-check
+envlist = py27,py34,py35,py36,pycodestyle,isort-check
 
 [testenv]
 deps =


### PR DESCRIPTION
The reason I still consider this WIP is because we still haven't acquired consensus over:

- Accept the current design
    - That is, to allow `url`, `password`, `verify` and the `conn` object. Note that, if you provide `conn` all other positional parameters are not used and vice-versa.
- Change the design
    - Allow one of both options: `To only use the HTTPConnection object (potentially exposing it for usage)` or `Only use url, password and verify to create the connection internally`.