### PR TITLE
Add "_raw" read-only properties to the endpoint classes

### DIFF
--- a/taxii2client/test/test_client.py
+++ b/taxii2client/test/test_client.py
@@ -272,9 +272,19 @@ def set_discovery_response(response):
                   content_type=MEDIA_TYPE_TAXII_V20)
 
 
+def set_collections_response():
+    responses.add(responses.GET, COLLECTIONS_URL, COLLECTIONS_RESPONSE,
+                  status=200, content_type=MEDIA_TYPE_TAXII_V20)
+
+
 def set_collection_response(url=COLLECTION_URL, response=COLLECTION_RESPONSE):
     responses.add(responses.GET, url, response, status=200,
                   content_type=MEDIA_TYPE_TAXII_V20)
+
+
+def set_status_response():
+    responses.add(responses.GET, STATUS_URL, STATUS_RESPONSE,
+                  status=200, content_type=MEDIA_TYPE_TAXII_V20)
 
 
 @responses.activate
@@ -295,6 +305,9 @@ def test_server_discovery(server):
     assert api_root.url == API_ROOT_URL
     assert api_root._loaded_information is False
     assert api_root._loaded_collections is False
+
+    discovery_dict = json.loads(DISCOVERY_RESPONSE)
+    assert server._raw == discovery_dict
 
 
 @responses.activate
@@ -389,8 +402,7 @@ def test_api_root_no_max_content_length(api_root):
 
 @responses.activate
 def test_api_root(api_root):
-    responses.add(responses.GET, API_ROOT_URL, API_ROOT_RESPONSE,
-                  status=200, content_type=MEDIA_TYPE_TAXII_V20)
+    set_api_root_response(API_ROOT_RESPONSE)
 
     assert api_root._loaded_information is False
     assert api_root.title == "Malware Research Group"
@@ -399,11 +411,13 @@ def test_api_root(api_root):
     assert api_root.versions == ["taxii-2.0"]
     assert api_root.max_content_length == 9765625
 
+    apiroot_dict = json.loads(API_ROOT_RESPONSE)
+    assert api_root._raw == apiroot_dict
+
 
 @responses.activate
 def test_api_root_collections(api_root):
-    responses.add(responses.GET, COLLECTIONS_URL, COLLECTIONS_RESPONSE, status=200,
-                  content_type=MEDIA_TYPE_TAXII_V20)
+    set_collections_response()
 
     assert api_root._loaded_collections is False
     assert len(api_root.collections) == 2
@@ -420,6 +434,9 @@ def test_api_root_collections(api_root):
     assert coll.can_write is False
     assert coll.media_types == [MEDIA_TYPE_STIX_V20]
 
+    collection_dict = json.loads(COLLECTION_RESPONSE)
+    assert coll._raw == collection_dict
+
 
 @responses.activate
 def test_collection(collection):
@@ -432,6 +449,9 @@ def test_collection(collection):
     assert collection.can_read is True
     assert collection.can_write is False
     assert collection.media_types == [MEDIA_TYPE_STIX_V20]
+
+    collection_dict = json.loads(COLLECTION_RESPONSE)
+    assert collection._raw == collection_dict
 
 
 def test_collection_unexpected_kwarg():
@@ -480,6 +500,9 @@ def test_add_object_to_collection(writable_collection):
     assert len(status.successes) == 1
     assert status.failure_count == 0
     assert status.pending_count == 0
+
+    status_dict = json.loads(ADD_OBJECTS_RESPONSE)
+    assert status._raw == status_dict
 
 
 @responses.activate
@@ -536,9 +559,8 @@ def test_get_manifest(collection):
 
 
 @responses.activate
-def test_get_status(api_root):
-    responses.add(responses.GET, STATUS_URL, STATUS_RESPONSE,
-                  status=200, content_type=MEDIA_TYPE_TAXII_V20)
+def test_get_status(api_root, status_dict):
+    set_status_response()
 
     status = api_root.get_status(STATUS_ID)
 
@@ -549,6 +571,17 @@ def test_get_status(api_root):
     assert len(status.failures) == 1
     assert status.pending_count == 2
     assert len(status.pendings) == 2
+
+    assert status._raw == status_dict
+
+
+@responses.activate
+def test_status_raw(status_dict):
+    """Test Status object created directly (not obtained via ApiRoot),
+    and _raw property."""
+    set_status_response()
+    status = Status(STATUS_URL)
+    assert status_dict == status._raw
 
 
 @responses.activate
@@ -675,7 +708,8 @@ def test_status_missing_id_property(status_dict):
     with pytest.raises(ValidationError) as excinfo:
         status_dict.pop("id")
         Status("https://example.com/api1/status/12345678-1234-1234-1234-123456789012/",
-               user="foo", password="bar", verify=False, **status_dict)
+               user="foo", password="bar", verify=False,
+               status_info=status_dict)
 
     assert "No 'id' in Status for request 'https://example.com/api1/status/12345678-1234-1234-1234-123456789012/'" == str(excinfo.value)
 
@@ -684,7 +718,8 @@ def test_status_missing_status_property(status_dict):
     with pytest.raises(ValidationError) as excinfo:
         status_dict.pop("status")
         Status("https://example.com/api1/status/12345678-1234-1234-1234-123456789012/",
-               user="foo", password="bar", verify=False, **status_dict)
+               user="foo", password="bar", verify=False,
+               status_info=status_dict)
 
     assert "No 'status' in Status for request 'https://example.com/api1/status/12345678-1234-1234-1234-123456789012/'" == str(excinfo.value)
 
@@ -693,7 +728,8 @@ def test_status_missing_total_count_property(status_dict):
     with pytest.raises(ValidationError) as excinfo:
         status_dict.pop("total_count")
         Status("https://example.com/api1/status/12345678-1234-1234-1234-123456789012/",
-               user="foo", password="bar", verify=False, **status_dict)
+               user="foo", password="bar", verify=False,
+               status_info=status_dict)
 
     assert "No 'total_count' in Status for request 'https://example.com/api1/status/12345678-1234-1234-1234-123456789012/'" == str(excinfo.value)
 
@@ -702,7 +738,8 @@ def test_status_missing_success_count_property(status_dict):
     with pytest.raises(ValidationError) as excinfo:
         status_dict.pop("success_count")
         Status("https://example.com/api1/status/12345678-1234-1234-1234-123456789012/",
-               user="foo", password="bar", verify=False, **status_dict)
+               user="foo", password="bar", verify=False,
+               status_info=status_dict)
 
     assert "No 'success_count' in Status for request 'https://example.com/api1/status/12345678-1234-1234-1234-123456789012/'" == str(excinfo.value)
 
@@ -711,7 +748,8 @@ def test_status_missing_failure_count_property(status_dict):
     with pytest.raises(ValidationError) as excinfo:
         status_dict.pop("failure_count")
         Status("https://example.com/api1/status/12345678-1234-1234-1234-123456789012/",
-               user="foo", password="bar", verify=False, **status_dict)
+               user="foo", password="bar", verify=False,
+               status_info=status_dict)
 
     assert "No 'failure_count' in Status for request 'https://example.com/api1/status/12345678-1234-1234-1234-123456789012/'" == str(excinfo.value)
 
@@ -720,7 +758,8 @@ def test_status_missing_pending_count_property(status_dict):
     with pytest.raises(ValidationError) as excinfo:
         status_dict.pop("pending_count")
         Status("https://example.com/api1/status/12345678-1234-1234-1234-123456789012/",
-               user="foo", password="bar", verify=False, **status_dict)
+               user="foo", password="bar", verify=False,
+               status_info=status_dict)
 
     assert "No 'pending_count' in Status for request 'https://example.com/api1/status/12345678-1234-1234-1234-123456789012/'" == str(excinfo.value)
 
@@ -729,7 +768,8 @@ def test_collection_missing_id_property(collection_dict):
     with pytest.raises(ValidationError) as excinfo:
         collection_dict.pop("id")
         Collection("https://example.com/api1/collections/91a7b528-80eb-42ed-a74d-c6fbd5a26116/",
-                   user="foo", password="bar", verify=False, **collection_dict)
+                   user="foo", password="bar", verify=False,
+                   collection_info=collection_dict)
 
     assert "No 'id' in Collection for request 'https://example.com/api1/collections/91a7b528-80eb-42ed-a74d-c6fbd5a26116/'" == str(excinfo.value)
 
@@ -738,7 +778,8 @@ def test_collection_missing_title_property(collection_dict):
     with pytest.raises(ValidationError) as excinfo:
         collection_dict.pop("title")
         Collection("https://example.com/api1/collections/91a7b528-80eb-42ed-a74d-c6fbd5a26116/",
-                   user="foo", password="bar", verify=False, **collection_dict)
+                   user="foo", password="bar", verify=False,
+                   collection_info=collection_dict)
 
     assert "No 'title' in Collection for request 'https://example.com/api1/collections/91a7b528-80eb-42ed-a74d-c6fbd5a26116/'" == str(excinfo.value)
 
@@ -747,7 +788,8 @@ def test_collection_missing_can_read_property(collection_dict):
     with pytest.raises(ValidationError) as excinfo:
         collection_dict.pop("can_read")
         Collection("https://example.com/api1/collections/91a7b528-80eb-42ed-a74d-c6fbd5a26116/",
-                   user="foo", password="bar", verify=False, **collection_dict)
+                   user="foo", password="bar", verify=False,
+                   collection_info=collection_dict)
 
     assert "No 'can_read' in Collection for request 'https://example.com/api1/collections/91a7b528-80eb-42ed-a74d-c6fbd5a26116/'" == str(excinfo.value)
 
@@ -756,6 +798,7 @@ def test_collection_missing_can_write_property(collection_dict):
     with pytest.raises(ValidationError) as excinfo:
         collection_dict.pop("can_write")
         Collection("https://example.com/api1/collections/91a7b528-80eb-42ed-a74d-c6fbd5a26116/",
-                   user="foo", password="bar", verify=False, **collection_dict)
+                   user="foo", password="bar", verify=False,
+                   collection_info=collection_dict)
 
     assert "No 'can_write' in Collection for request 'https://example.com/api1/collections/91a7b528-80eb-42ed-a74d-c6fbd5a26116/'" == str(excinfo.value)


### PR DESCRIPTION
This allows users to access the raw (parsed) JSON used to build the instances.  Fixes #39 .

Note that this changes the public API in a backward-incompatible way.  Previously, when a "parent" endpoint instance constructs a "child" endpoint instance (e.g. apiroot creates and returns a collection), the JSON used to create the child instance was not passed into it.  This makes it impossible for the child instance to return that JSON in its "_raw" property.  What had been done was to break up the JSON into separate keyword args using the `**json_dict` syntax.  That means the child instance gets the data but not the JSON itself.  I changed APIs where necessary so that the (parsed) JSON is passed in.