### PR TITLE
Support for User-Agent headers

### DIFF
--- a/taxii2client/__init__.py
+++ b/taxii2client/__init__.py
@@ -855,7 +855,16 @@ class _HTTPConnection(object):
 
         """
 
-        merged_headers = self._merge_headers(headers)
+        # Let the "accept" param to this method override the content of
+        # the "headers" param.
+        if headers:
+            method_headers = requests.structures.CaseInsensitiveDict(headers)
+        else:
+            method_headers = {}
+
+        method_headers["Accept"] = accept
+
+        merged_headers = self._merge_headers(method_headers)
 
         resp = self.session.get(url, headers=merged_headers, params=params)
 

--- a/taxii2client/test/test_client.py
+++ b/taxii2client/test/test_client.py
@@ -6,10 +6,10 @@ import responses
 import six
 
 from taxii2client import (
-    MEDIA_TYPE_STIX_V20, MEDIA_TYPE_TAXII_V20, AccessError, ApiRoot,
-    Collection, InvalidArgumentsError, InvalidJSONError, Server, Status,
-    TAXIIServiceException, ValidationError, _filter_kwargs_to_query_params,
-    _HTTPConnection, _TAXIIEndpoint
+    MEDIA_TYPE_STIX_V20, MEDIA_TYPE_TAXII_V20, DEFAULT_USER_AGENT, AccessError,
+    ApiRoot, Collection, InvalidArgumentsError, InvalidJSONError, Server,
+    Status, TAXIIServiceException, ValidationError,
+    _filter_kwargs_to_query_params, _HTTPConnection, _TAXIIEndpoint
 )
 
 TAXII_SERVER = "example.com"
@@ -813,3 +813,58 @@ def test_collection_missing_can_write_property(collection_dict):
                    collection_info=collection_dict)
 
     assert "No 'can_write' in Collection for request 'https://example.com/api1/collections/91a7b528-80eb-42ed-a74d-c6fbd5a26116/'" == str(excinfo.value)
+
+
+def test_user_agent_defaulting():
+    conn = _HTTPConnection(user_agent="foo/1.0")
+    headers = conn._merge_headers({})
+
+    # also test key access is case-insensitive
+    assert headers["user-agent"] == "foo/1.0"
+
+
+def test_user_agent_overriding():
+    conn = _HTTPConnection(user_agent="foo/1.0")
+    headers = conn._merge_headers({"User-Agent": "bar/2.0"})
+
+    assert headers["user-agent"] == "bar/2.0"
+
+
+def test_user_agent_enforcing1():
+    conn = _HTTPConnection(user_agent=None)
+    headers = conn._merge_headers({})
+
+    assert headers["user-agent"] == DEFAULT_USER_AGENT
+
+
+def test_user_agent_enforcing2():
+    conn = _HTTPConnection()
+    headers = conn._merge_headers({"User-Agent": None})
+
+    assert headers["user-agent"] == DEFAULT_USER_AGENT
+
+
+def test_user_agent_enforcing3():
+    conn = _HTTPConnection(user_agent=None)
+    headers = conn._merge_headers({"User-Agent": None})
+
+    assert headers["user-agent"] == DEFAULT_USER_AGENT
+
+
+def test_header_merging():
+    conn = _HTTPConnection()
+    headers = conn._merge_headers({"AddedHeader": "addedvalue"})
+
+    assert headers == {
+        "user-agent": DEFAULT_USER_AGENT,
+        "addedheader": "addedvalue"
+    }
+
+
+def test_header_merge_none():
+    conn = _HTTPConnection()
+    headers = conn._merge_headers(None)
+
+    assert headers == {
+        "user-agent": DEFAULT_USER_AGENT
+    }

--- a/taxii2client/test/test_client.py
+++ b/taxii2client/test/test_client.py
@@ -6,7 +6,7 @@ import responses
 import six
 
 from taxii2client import (
-    MEDIA_TYPE_STIX_V20, MEDIA_TYPE_TAXII_V20, DEFAULT_USER_AGENT, AccessError,
+    DEFAULT_USER_AGENT, MEDIA_TYPE_STIX_V20, MEDIA_TYPE_TAXII_V20, AccessError,
     ApiRoot, Collection, InvalidArgumentsError, InvalidJSONError, Server,
     Status, TAXIIServiceException, ValidationError,
     _filter_kwargs_to_query_params, _HTTPConnection, _TAXIIEndpoint

--- a/taxii2client/test/test_client.py
+++ b/taxii2client/test/test_client.py
@@ -697,7 +697,8 @@ def test_valid_content_type_for_connection():
                   content_type=MEDIA_TYPE_TAXII_V20 + "; charset=utf-8")
 
     conn = _HTTPConnection(user="foo", password="bar", verify=False)
-    conn.get("https://example.com/api1/collections/91a7b528-80eb-42ed-a74d-c6fbd5a26116/", MEDIA_TYPE_TAXII_V20, None)
+    conn.get("https://example.com/api1/collections/91a7b528-80eb-42ed-a74d-c6fbd5a26116/",
+             headers={"Accept": MEDIA_TYPE_TAXII_V20})
 
 
 @responses.activate
@@ -708,7 +709,8 @@ def test_invalid_content_type_for_connection():
 
     with pytest.raises(TAXIIServiceException) as excinfo:
         conn = _HTTPConnection(user="foo", password="bar", verify=False)
-        conn.get("https://example.com/api1/collections/91a7b528-80eb-42ed-a74d-c6fbd5a26116/", MEDIA_TYPE_TAXII_V20 + "; charset=utf-8", None)
+        conn.get("https://example.com/api1/collections/91a7b528-80eb-42ed-a74d-c6fbd5a26116/",
+                 headers={"Accept": MEDIA_TYPE_TAXII_V20 + "; charset=utf-8"})
 
     assert ("Unexpected Response. Got Content-Type: 'application/vnd.oasis.taxii+json; "
             "version=2.0' for Accept: 'application/vnd.oasis.taxii+json; version=2.0; "


### PR DESCRIPTION
These changes add support for customizing the "User-Agent" header in requests.  Also added some more unit tests.  This fixes #40.  In more detail:

- user_agent may be passed to the _HTTPConnection constructor; this will act as a default value for all get's and post's.
- It is not possible to force requests to not have a user-agent header, nor is it possible to trigger usage of the the default from the requests library.  The decision is that user-agent is always present, and is either a user customized value, or a taxii2-client-specific default.
- _HTTPConnection.post() already had a "headers" parameter, where user-agent could have been customized.  As described above, a user-agent header given here will override a value passed to the connection constructor.
- _HTTPConnection.get() did not have a headers parameter, making the method signatures curiously inconsistent.  So a headers parameter was added.  Unfortunately, the get/post signatures are still curiously inconsistent as far as parameter order.  Get parameter order is (url, accept, params, headers), whereas post parameter order is (url, headers, params, data).  So in get(), params comes before headers, and in post(), params comes after headers.  I chose to append the headers parameter to the end of the get() parameter list to keep it backward-compatible.  In case someone passed "params" positionally to get(), that will continue to work.  Wish this could be better!
- Adding the headers parameter to get() added another necessary deconfliction: the "Accept" header could be set in the headers parameter or the accept parameter.  So I had to decide how those interact.  My decision was that the accept parameter overrides any "Accept" header which might exist in headers.  The root of this weirdness is that someone thought post() needed full headers customization via a "headers" parameter, but get() only needed to customize the Accept header.  Maybe these signatures should have been kept more symmetric from the beginning.
- Header merging needs to address the issue of case of the header names.  E.g. one could pass "user-agent" as a header name in post(), but the user_agent param to the constructor is set as the value of the "User-Agent" header.  The requests library will internally merge the headers case-insensitively, but it won't be predictable.  One of "user-agent" and "User-Agent" will be chosen.  I thought the simplest way to address this was to use a special dict-like class which handles keys case-insensitively.  That way, you never have entries whose keys differ only in case.  The requests library has one within it named CaseInsensitiveDict, but I don't know if it's public API.  But I used it.  So usage of that class has been introduced.

If/when we are able to break backward-compatibility, the weirdnesses described above can be cleaned up.