### PR TITLE
Improved JSON handling

### DIFF
--- a/taxii2client/__init__.py
+++ b/taxii2client/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import unicode_literals
 
 import datetime
+import json
 import time
 
 import pytz
@@ -493,7 +494,7 @@ class Collection(_TAXIIEndpoint):
         expires, or the operation completes.
 
         Args:
-            bundle (str): A STIX bundle with the objects to add.
+            bundle: A STIX bundle with the objects to add (string, dict, binary)
             wait_for_completion (bool): Whether to wait for the add operation
                 to complete before returning
             poll_interval (int): If waiting for completion, how often to poll
@@ -522,8 +523,22 @@ class Collection(_TAXIIEndpoint):
             "Content-Type": content_type,
         }
 
+        if isinstance(bundle, dict):
+            json_text = json.dumps(bundle, ensure_ascii=False)
+            data = json_text.encode("utf-8")
+
+        elif isinstance(bundle, six.text_type):
+            data = bundle.encode("utf-8")
+
+        elif isinstance(bundle, six.binary_type):
+            data = bundle
+
+        else:
+            raise TypeError("Don't know how to handle type '{}'".format(
+                type(bundle).__name__))
+
         status_json = self._conn.post(self.objects_url, headers=headers,
-                                      json=bundle)
+                                      data=data)
 
         status_url = urlparse.urljoin(
             self.url,

--- a/taxii2client/test/test_client.py
+++ b/taxii2client/test/test_client.py
@@ -534,6 +534,34 @@ def test_add_object_to_collection_dict(writable_collection):
 
 
 @responses.activate
+def test_add_object_to_collection_bin(writable_collection):
+    responses.add(responses.POST, ADD_WRITABLE_OBJECTS_URL,
+                  ADD_OBJECTS_RESPONSE, status=202,
+                  content_type=MEDIA_TYPE_TAXII_V20)
+
+    bin_bundle = STIX_BUNDLE.encode("utf-8")
+
+    status = writable_collection.add_objects(bin_bundle)
+
+    assert status.status == "complete"
+    assert status.total_count == 1
+    assert status.success_count == 1
+    assert len(status.successes) == 1
+    assert status.failure_count == 0
+    assert status.pending_count == 0
+
+
+@responses.activate
+def test_add_object_to_collection_badtype(writable_collection):
+    responses.add(responses.POST, ADD_WRITABLE_OBJECTS_URL,
+                  ADD_OBJECTS_RESPONSE, status=202,
+                  content_type=MEDIA_TYPE_TAXII_V20)
+
+    with pytest.raises(TypeError):
+        writable_collection.add_objects([1, 2, 3])
+
+
+@responses.activate
 def test_add_object_rases_error_when_collection_id_does_not_match_url(
         bad_writable_collection):
     responses.add(responses.POST, ADD_OBJECTS_URL, ADD_OBJECTS_RESPONSE,

--- a/taxii2client/test/test_client.py
+++ b/taxii2client/test/test_client.py
@@ -813,3 +813,16 @@ def test_collection_missing_can_write_property(collection_dict):
                    collection_info=collection_dict)
 
     assert "No 'can_write' in Collection for request 'https://example.com/api1/collections/91a7b528-80eb-42ed-a74d-c6fbd5a26116/'" == str(excinfo.value)
+
+
+def test_conn_post_kwarg_errors():
+    conn = _HTTPConnection()
+
+    with pytest.raises(InvalidArgumentsError):
+        conn.post(DISCOVERY_URL, data=1, json=2)
+
+    with pytest.raises(InvalidArgumentsError):
+        conn.post(DISCOVERY_URL, data=1, foo=2)
+
+    with pytest.raises(InvalidArgumentsError):
+        conn.post(DISCOVERY_URL, foo=1)


### PR DESCRIPTION
Removed python-version-specific code, since it didn't do anything.  Allow the "json=" kwarg to _HTTPConnection.post(), for a simpler way of posting JSON which leverages the requests library's builtin capabilities.  Fixes #46 .