### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -74,7 +74,7 @@ You can follow references to ``ApiRoot`` objects,
    api_root = server.api_roots[0]
    collection = api_root.collections[0]
    collection.add_objects(stix_bundle)
-   
+
 Additionally, you can access ``ApiRoot`` objects directly through the URL (which can be especially
 helpful when running a server and client on localhost):
 

--- a/README.rst
+++ b/README.rst
@@ -75,10 +75,11 @@ You can follow references to ``ApiRoot`` objects,
    collection = api_root.collections[0]
    collection.add_objects(stix_bundle)
    
-Additionally, you can access ``ApiRoot`` objects directly through the URL (which can be especially helpful when running a server and client on localhost):
+Additionally, you can access ``ApiRoot`` objects directly through the URL (which can be especially
+helpful when running a server and client on localhost):
 
 .. code:: python
-   
+
    server = Server('https://example.com/<ApiRoot Name>/', user='user_id', password='user_password')
 
 Each ``ApiRoot`` has attributes corresponding to its meta data

--- a/README.rst
+++ b/README.rst
@@ -74,6 +74,12 @@ You can follow references to ``ApiRoot`` objects,
    api_root = server.api_roots[0]
    collection = api_root.collections[0]
    collection.add_objects(stix_bundle)
+   
+Additionally, you can access ``ApiRoot`` objects directly through the URL (which can be especially helpful when running a server and client on localhost):
+
+.. code:: python
+   
+   server = Server('https://example.com/<ApiRoot Name>/', user='user_id', password='user_password')
 
 Each ``ApiRoot`` has attributes corresponding to its meta data
 


### PR DESCRIPTION
Added a line to specify you can access Api root objects through a URL. This would've saved me about 2 hours, so it may be useful for others.