### PR TITLE
Fix "Range" header according to TAXII version 2.0 documenation

### DIFF
--- a/taxii2client/v20/__init__.py
+++ b/taxii2client/v20/__init__.py
@@ -375,7 +375,7 @@ class Collection(_TAXIIEndpoint):
         headers = {"Accept": accept}
 
         if per_request > 0:
-            headers["Range"] = "items={}-{}".format(start, (start + per_request) - 1)
+            headers["Range"] = "items {}-{}".format(start, (start + per_request) - 1)
 
         return self._conn.get(self.objects_url, headers=headers, params=query_params)
 

--- a/taxii2client/v20/__init__.py
+++ b/taxii2client/v20/__init__.py
@@ -375,9 +375,20 @@ class Collection(_TAXIIEndpoint):
         headers = {"Accept": accept}
 
         if per_request > 0:
-            headers["Range"] = "items {}-{}".format(start, (start + per_request) - 1)
+            headers["Range"] = "items={}-{}".format(start, (start + per_request) - 1)
 
-        return self._conn.get(self.objects_url, headers=headers, params=query_params)
+        try:
+            response = self._conn.get(self.objects_url, headers=headers, params=query_params)
+
+        except requests.HTTPError as e:
+            if per_request > 0:
+                headers["Range"] = "items {}-{}".format(start, (start + per_request) - 1)
+
+                response = self._conn.get(self.objects_url, headers=headers, params=query_params)
+            else:
+                raise requests.HTTPError(e)
+
+        return response
 
     def get_object(self, obj_id, version=None, accept=MEDIA_TYPE_STIX_V20):
         """Implement the ``Get an Object`` endpoint (section 5.5)"""


### PR DESCRIPTION
We are using TAXII2.0 servers that started failing lately, after the merge of the following PR: https://github.com/oasis-open/cti-taxii-client/pull/75

According to the documentation of TAXII2.0 the `Range` header should not have the `=` prior to the range desired.

Link to the part in the documentation stating this:
http://docs.oasis-open.org/cti/taxii/v2.0/cs01/taxii-v2.0-cs01.html#_Toc496542716