### PR TITLE
Remove the extra space in the Content-Type

### DIFF
--- a/taxii2client/__init__.py
+++ b/taxii2client/__init__.py
@@ -18,7 +18,7 @@ log.addHandler(ch)
 DEFAULT_USER_AGENT = "taxii2-client/2.2.2"
 MEDIA_TYPE_STIX_V20 = "application/vnd.oasis.stix+json; version=2.0"
 MEDIA_TYPE_TAXII_V20 = "application/vnd.oasis.taxii+json; version=2.0"
-MEDIA_TYPE_TAXII_V21 = "application/taxii+json; version=2.1"
+MEDIA_TYPE_TAXII_V21 = "application/taxii+json;version=2.1"
 
 from .v21 import *  # This import will always be the latest TAXII 2.X version
 from .version import __version__

--- a/taxii2client/test/test_client_v21.py
+++ b/taxii2client/test/test_client_v21.py
@@ -666,7 +666,7 @@ def test_content_type_invalid(collection):
     with pytest.raises(TAXIIServiceException) as excinfo:
         collection.get_object("indicator--252c7c11-daf2-42bd-843b-be65edca9f61")
     assert ("Unexpected Response. Got Content-Type: 'taxii' for "
-            "Accept: 'application/taxii+json; version=2.1'") in str(excinfo.value)
+            "Accept: 'application/taxii+json;version=2.1'") in str(excinfo.value)
 
 
 def test_url_filter_type():
@@ -782,8 +782,8 @@ def test_invalid_content_type_for_connection():
         conn.get("https://example.com/api1/collections/91a7b528-80eb-42ed-a74d-c6fbd5a26116/",
                  headers={"Accept": MEDIA_TYPE_TAXII_V21 + "; charset=utf-8"})
 
-    assert ("Unexpected Response. Got Content-Type: 'application/taxii+json; "
-            "version=2.1' for Accept: 'application/taxii+json; version=2.1; "
+    assert ("Unexpected Response. Got Content-Type: 'application/taxii+json;"
+            "version=2.1' for Accept: 'application/taxii+json;version=2.1; "
             "charset=utf-8'") in str(excinfo.value)
 
 


### PR DESCRIPTION
According to  [TAXII-2.1](https://docs.oasis-open.org/cti/taxii/v2.1/cs01/taxii-v2.1-cs01.html#_Toc31107506), there is no spaces between the media type and the version parameter : `application/taxii+json;version=2.1`.

This is not the case for [TAXII-2.0](http://docs.oasis-open.org/cti/taxii/v2.0/cs01/taxii-v2.0-cs01.html#_Toc496542707) : `application/vnd.oasis.taxii+json; version=2.0`.

The section 3.1.1.1 of [RFC7231](https://www.rfc-editor.org/rfc/rfc7231.html#section-3.1.1), the following examples are all equivalent, but the first is preferred for consistency:

```
text/html;charset=utf-8
text/html;charset=UTF-8
Text/HTML;Charset="utf-8"
text/html; charset="utf-8"
```

Event if `application/taxii+json;version=2.1` is equivalent to `application/taxii+json; version=2.1`,  `application/taxii+json;version=2.1` should be preferred. 