### PR TITLE
Fix for issue #113, AttributeError: 'dict' object has no attribute 'json' exception

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@ tag = True
 [bumpversion:file:taxii2client/__init__.py]
 
 [metadata]
-license_file = LICENSE
+license_files = LICENSE
 
 [bdist_wheel]
 universal = 1

--- a/taxii2client/common.py
+++ b/taxii2client/common.py
@@ -202,16 +202,16 @@ class TaxiiResponse(Mapping):
     class that can act like either.
     """
     def __init__(self, resp: requests.Response):
-        self.resp      = resp
-        self.json_dict = _to_json(self.resp) 
-    
+        self.resp = resp
+        self.json_dict = _to_json(self.resp)
+
     def json(self):
         return self.json_dict
-    
+
     # Pass through attributes to the resp so we can get things like headers
     def __getattr__(self, name):
         return self.resp.__getattribute__(name)
-    
+
     # Mapping implementation for dict (and mostly **) compatibility
     def __iter__(self):
         return self.json_dict.__iter__()
@@ -310,7 +310,7 @@ class _HTTPConnection(object):
                 request. (optional)
 
         """
-        
+
         merged_headers = self._merge_headers(headers)
 
         if self.version == "2.0":

--- a/taxii2client/common.py
+++ b/taxii2client/common.py
@@ -195,6 +195,12 @@ class _TAXIIEndpoint(object):
 
 
 class TaxiiResponse(Mapping):
+    """
+    The _HTTPConnection.get call return value is sometimes a dict, and
+    sometimes a requests.Response. Rather than having it guess at what the
+    caller wants to see (and sometimes getting it wrong) wrap the result in a
+    class that can act like either.
+    """
     def __init__(self, resp: requests.Response):
         self.resp      = resp
         self.json_dict = _to_json(self.resp) 

--- a/taxii2client/v20/__init__.py
+++ b/taxii2client/v20/__init__.py
@@ -13,7 +13,7 @@ from six.moves.urllib import parse as urlparse
 from .. import MEDIA_TYPE_STIX_V20, MEDIA_TYPE_TAXII_V20
 from ..common import (
     _filter_kwargs_to_query_params, _grab_total_items_from_resource,
-    _TAXIIEndpoint, _to_json
+    _TAXIIEndpoint
 )
 from ..exceptions import AccessError, InvalidJSONError, ValidationError
 
@@ -33,7 +33,7 @@ def as_pages(func, start=0, per_request=0, *args, **kwargs):
     Use args or kwargs to pass filter information or other arguments required to make the call.
     """
     resp = func(start=start, per_request=per_request, *args, **kwargs)
-    yield _to_json(resp)
+    yield resp
     total_obtained, total_available = _grab_total_items(resp)
 
     if total_available > per_request and total_obtained != per_request and total_obtained != float("inf"):
@@ -44,7 +44,7 @@ def as_pages(func, start=0, per_request=0, *args, **kwargs):
     while start < total_available:
 
         resp = func(start=start, per_request=per_request, *args, **kwargs)
-        yield _to_json(resp)
+        yield resp
 
         total_in_request, total_available = _grab_total_items(resp)
         start += per_request


### PR DESCRIPTION
Right now _HTTPConnection.get() can return either a dict or a requests.Response depending on what it thinks the calling function wants. This creates some type confusion, and in certain circumstances results in _to_json being called on a dict instead of a Response, causing an exception.

There are a bunch of different ways to work around this, but I took the route of trying to fix the base type conduction problem by wrapping the requests.Response in an object that can satisfy both the callers that want a dict or the headers from requests.Response and making the get behavior consistent. That means the _to_json calls can be removed and the exception never fires.

All unit tests pass, but I haven't been able to sign off on the CLA yet as the link for it no longer appears to function (https://www.oasis-open.org/resources/open-repositories/cla/individual-cla). If someone can point me to one that works I'll get it taken care of.