### PR TITLE
Fix ci workflow

### DIFF
--- a/.github/workflows/python-ci-tests.yml
+++ b/.github/workflows/python-ci-tests.yml
@@ -13,9 +13,9 @@ jobs:
 
     name: Python ${{ matrix.python-version }} Build
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install and update essential dependencies
@@ -27,7 +27,7 @@ jobs:
       run: |
         tox
     - name: Upload coverage information to Codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3
       with:
         fail_ci_if_error: true # optional (default = false)
         verbose: true # optional (default = false)

--- a/.github/workflows/python-ci-tests.yml
+++ b/.github/workflows/python-ci-tests.yml
@@ -6,7 +6,7 @@ on: [push, pull_request]
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+    rev: v4.4.0
     hooks:
     -   id: trailing-whitespace
     -   id: check-merge-conflict
 -   repo: https://github.com/PyCQA/flake8
-    rev: 3.8.4
+    rev: 6.0.0
     hooks:
     -   id: flake8
         name: Check project styling

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
         args:
         - --max-line-length=160
 -   repo: https://github.com/PyCQA/isort
-    rev: 5.7.0
+    rev: 5.12.0
     hooks:
     -   id: isort
         name: Sort python imports (shows diff)

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,6 @@ envlist = py36,py37,py38,py39,packaging,pre-commit-check
 
 [testenv]
 deps =
-  -U
   tox
   pytest
   pytest-cov


### PR DESCRIPTION
The CI workflow doesn't seem to have been updated in a few years, and is broken in its current state. Bring it up to date so it can evaluate new PRs.

- A number of the old Github Actions are deprecated and run under old version of NodeJS that doesn't work on the GitHub runners. They've all been bumped to current versions.
- We were previously using ubuntu-latest, which switched from 20.04 -> 22.04 in the last few years. 20.04 doesn't have python 3.6 support, so explicitly use 20.04 for now. It can change back to ubuntu-latest when support for Python 3.6 is officially removed from the package.
- I don't know what the tox -U option used to do, but it no longer exists and causes an error. Get rid of it.
- isort had an issue with Python 3.9 that caused the pre-commit config to die. This was fixed in isort 5.12.0 