### PR TITLE
Added support for api key authentication, using an api key or bearer token

### DIFF
--- a/taxii2client/common.py
+++ b/taxii2client/common.py
@@ -143,6 +143,14 @@ class TokenAuth(requests.auth.AuthBase):
         r.headers['Authorization'] = 'Token {}'.format(self.key)
         return r
 
+class ApiKeyAuth(requests.auth.AuthBase):
+    def __init__(self, api_key, value):
+        self.api_key = api_key
+        self.value = value
+
+    def __call__(self, r):
+        r.headers[self.api_key] = "{}".format(self.value)
+        return r
 
 class _TAXIIEndpoint(object):
     """Contains some data and functionality common to all TAXII endpoint

--- a/taxii2client/test/test_client_v20.py
+++ b/taxii2client/test/test_client_v20.py
@@ -12,6 +12,9 @@ from taxii2client import (
 from taxii2client.common import (
     TokenAuth, _filter_kwargs_to_query_params, _HTTPConnection, _TAXIIEndpoint
 )
+from taxii2client.common import (
+    ApiKeyAuth, _filter_kwargs_to_query_params, _HTTPConnection, _TAXIIEndpoint
+)
 from taxii2client.exceptions import (
     AccessError, InvalidArgumentsError, InvalidJSONError,
     TAXIIServiceException, ValidationError
@@ -981,6 +984,11 @@ def test_taxii_endpoint_raises_exception():
 
     with pytest.raises(InvalidArgumentsError) as excinfo:
         _TAXIIEndpoint(fake_url, conn, "other", "test", auth=TokenAuth('abcd'))
+
+    assert error_str in str(excinfo.value)
+
+    with pytest.raises(InvalidArgumentsError) as excinfo:
+        _TAXIIEndpoint(fake_url, conn, auth=ApiKeyAuth('foo','bar123'))
 
     assert error_str in str(excinfo.value)
 

--- a/taxii2client/test/test_client_v21.py
+++ b/taxii2client/test/test_client_v21.py
@@ -10,6 +10,9 @@ from taxii2client import DEFAULT_USER_AGENT, MEDIA_TYPE_TAXII_V21
 from taxii2client.common import (
     TokenAuth, _filter_kwargs_to_query_params, _HTTPConnection, _TAXIIEndpoint
 )
+from taxii2client.common import (
+    ApiKeyAuth, _filter_kwargs_to_query_params, _HTTPConnection, _TAXIIEndpoint
+)
 from taxii2client.exceptions import (
     AccessError, InvalidArgumentsError, InvalidJSONError,
     TAXIIServiceException, ValidationError
@@ -789,6 +792,11 @@ def test_taxii_endpoint_raises_exception():
 
     with pytest.raises(InvalidArgumentsError) as excinfo:
         _TAXIIEndpoint(fake_url, conn, "other", "test", auth=TokenAuth('abcd'))
+
+    assert error_str in str(excinfo.value)
+
+    with pytest.raises(InvalidArgumentsError) as excinfo:
+        _TAXIIEndpoint(fake_url, conn, auth=ApiKeyAuth('foo','bar123'))
 
     assert error_str in str(excinfo.value)
 


### PR DESCRIPTION
During developing vendor integrations, we've bumped into the issue that natively only username/password or TokenAuth is supported, but in the situation of OpenCTI and NCSC NL API we use an api key or bearer token.

Would be great to have support directly into the cti-taxii-client, so I can use this with Splunk (CTIS OSS) and our user population doesn't have to define a custom class to load.

I also updated both `pytests`  to include this new  class providing the  *ApiKeyAuth* feature.